### PR TITLE
Rebranding

### DIFF
--- a/app/includes/footer-disclaimer-modal.tpl
+++ b/app/includes/footer-disclaimer-modal.tpl
@@ -11,7 +11,7 @@
 
         <p class="small"><strong>Always backup your keys: </strong> Pyrus & Pyrus CX are not "web wallets". You do not create an account or give us your UBQ to hold onto. All data never leaves your computer/your browser. We make it easy for you to create, save, and access your information and interact with the blockchain.</p>
 
-        <p class="small"><strong>We are not responsible for any loss: </strong> Ethereum, Pyrus & Pyrus CX, and some of the underlying Javascript libraries we use are under active development. While we have thoroughly tested & tens of thousands of wallets have been successfully created by people all over the globe, there is always the remote possibility that something unexpected happens that causes your UBQ to be lost. Please do not invest more than you are willing to lose, and please be careful. If something were to happen, we are sorry, but we are not responsible for the lost UBQ.</p>
+        <p class="small"><strong>We are not responsible for any loss: </strong> Ubiq, Pyrus & Pyrus CX, and some of the underlying Javascript libraries we use are under active development. While we have thoroughly tested & tens of thousands of wallets have been successfully created by people all over the globe, there is always the remote possibility that something unexpected happens that causes your UBQ to be lost. Please do not invest more than you are willing to lose, and please be careful. If something were to happen, we are sorry, but we are not responsible for the lost UBQ.</p>
 
         <p class="small"><strong>MIT License</strong> Copyright &copy; 2015-2017 Ubiq Developers</p>
 


### PR DESCRIPTION
Remove "Ethereum" and replace with "Ubiq" in disclaimer located in footer.